### PR TITLE
ZD-63913: Corrected Binary Directory; Nomad Job, Consul Service for DNS testing.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@
 # Ignore licenses .lic or .hclic
 *.lic
 *.hclic
+examples/.DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,4 @@
 # Ignore licenses .lic or .hclic
 *.lic
 *.hclic
-examples/.DS_Store
+*.DS_Store

--- a/examples/client2-svc2.nomad
+++ b/examples/client2-svc2.nomad
@@ -1,0 +1,35 @@
+job "client2-svc2" {
+  datacenters = ["emea-dc1"]
+
+  group "svc2" {
+    network {
+      port "test" {
+        to = 9090
+      }
+    }
+
+    service {
+      name = "client2-svc2"
+      tags = ["${NOMAD_ALLOC_INDEX}", "${NOMAD_ALLOC_ID}"]
+      port = 9090
+      
+    }
+
+    task "svc2" {
+      driver = "docker"
+
+      config {
+        image = "nicholasjackson/fake-service:v0.7.8"
+      }
+
+      env {
+        MESSAGE = "hello from svc2 in DC ${ datacenter }"
+      }
+
+      resources {
+        cpu    = 100
+        memory = 100
+      }
+    }
+  }
+}

--- a/scripts/emea.sh
+++ b/scripts/emea.sh
@@ -10,7 +10,7 @@ curl -fsSL https://releases.hashicorp.com/nomad/${NOMAD_VERSION}+ent/nomad_${NOM
 unzip nomad.zip
 sudo useradd --system --home /etc/nomad.d --shell /bin/false nomad
 chown root:root nomad
-mv nomad /usr/local/bin/
+mv nomad /usr/bin/
 
 # create directories
 mkdir -p /opt/nomad
@@ -34,13 +34,13 @@ curl -fsSL https://func-e.io/install.sh | bash -s -- -b /usr/local/bin
 sudo cp `func-e which` /usr/local/bin
 
 # consul
-export CONSUL_VERSION="1.11.2"
+export CONSUL_VERSION="1.11.4"
 curl -fsSL https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip -o consul.zip
 # curl -fsSL https://releases.hashicorp.com/consul/${CONSUL_VERSION}+ent/consul_${CONSUL_VERSION}+ent_linux_amd64.zip -o consul.zip
 unzip consul.zip
 useradd --system --home /etc/consul.d --shell /bin/false consul
 chown root:root consul
-mv consul /usr/local/bin/
+mv consul /usr/bin/
 
 # copy service config
 cp -ap /vagrant/conf/consul.service /etc/systemd/system/consul.service

--- a/scripts/usa.sh
+++ b/scripts/usa.sh
@@ -10,7 +10,7 @@ curl -fsSL https://releases.hashicorp.com/nomad/${NOMAD_VERSION}+ent/nomad_${NOM
 unzip nomad.zip
 sudo useradd --system --home /etc/nomad.d --shell /bin/false nomad
 chown root:root nomad
-mv nomad /usr/local/bin/
+mv nomad /usr/bin/
 
 # create directories
 mkdir -p /opt/nomad
@@ -35,13 +35,13 @@ sudo cp `func-e which` /usr/local/bin
 
 
 # CONSUL OSS or ENTERPRISE manually
-export CONSUL_VERSION="1.11.2"
+export CONSUL_VERSION="1.11.4"
 curl -fsSL https://releases.hashicorp.com/consul/${CONSUL_VERSION}/consul_${CONSUL_VERSION}_linux_amd64.zip -o consul.zip
 # curl -fsSL https://releases.hashicorp.com/consul/${CONSUL_VERSION}+ent/consul_${CONSUL_VERSION}+ent_linux_amd64.zip -o consul.zip
 unzip consul.zip
 useradd --system --home /etc/consul.d --shell /bin/false consul
 chown root:root consul
-mv consul /usr/local/bin/
+mv consul /usr/bin/
 
 # copy service config
 cp -ap /vagrant/conf/consul.service /etc/systemd/system/consul.service


### PR DESCRIPTION
These changes reflect updates to support [ZD-63913](https://hashicorp.zendesk.com/agent/tickets/63913).  The changes were authored by Consul Support Engineer Mark Cambell-Vincent.  They include:
* Correcting the directory where the Nomad and Consul binarys go, where Service Exec expects to find them.
* Adding the Nomad job specification file `client2-svc2.nomad` to create a Consul service for DNS testing.
* A DNS test procedure in `README.md` to test DNS connection between federated nodes.

I successfully tested the changes in this branch before pushing to this repository, using `README.md` as a guide.